### PR TITLE
add test to check for dynamic assignment

### DIFF
--- a/test/index-test.js
+++ b/test/index-test.js
@@ -27,6 +27,11 @@ describe('#addToCart', function() {
   it("returns the cart", function() {
     expect(addToCart("pizza")).toEqual(getCart())
   })
+
+  it("adds item dynamically", function() {
+    addToCart('pizza');
+    expect(getCart()[0]['item']).toEqual(undefined)
+  })
 });
 
 describe('#viewCart', function() {


### PR DESCRIPTION
Checks for `{[item]: price}` as opposed to `{item: price}`.

CC: @aturkewi 