### PR TITLE
Modify dynamic assignment test - solution branch

### DIFF
--- a/test/index-test.js
+++ b/test/index-test.js
@@ -30,8 +30,6 @@ describe('#addToCart', function() {
 
   it("adds item dynamically", function() {
     addToCart('pizza');
-    //we've pushed an object with the property 'pizza', not 'item'
-    //It should be: {pizza: 44}, not {item: 44}
     expect(getCart()[0].hasOwnProperty('item')).toEqual(false);
   })
 });

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -30,7 +30,9 @@ describe('#addToCart', function() {
 
   it("adds item dynamically", function() {
     addToCart('pizza');
-    expect(getCart()[0]['item']).toEqual(undefined)
+    //we've pushed an object with the property 'pizza', not 'item'
+    //It should be: {pizza: 44}, not {item: 44}
+    expect(getCart()[0].hasOwnProperty('item')).toEqual(false);
   })
 });
 


### PR DESCRIPTION
On a Q with a student the other day I saw that my new test to check for dynamic assignment of `[item]` as opposed to `item` will give a false positive if `price` is `undefined`.

I modified my existing test to use `hasOwnProperty` instead of how I was doing it before.

CC: @aturkewi 